### PR TITLE
Fix: Imports for `crypto-random-string`

### DIFF
--- a/src/store/dataQuery/stubDataQuery.ts
+++ b/src/store/dataQuery/stubDataQuery.ts
@@ -1,5 +1,5 @@
-const cryptoRandomString = require('crypto-random-string');
 
+import cryptoRandomString from "crypto-random-string";
 import {iStoreDataQuery} from "../models/iStoreDataQuery";
 import {iHospital} from "../models/iHospital";
 

--- a/src/view/views/baseView.ts
+++ b/src/view/views/baseView.ts
@@ -1,6 +1,6 @@
 import {iAddressFormatter} from "../../common/models/iAddressFormatter";
 
-const cryptoRandomString = require('crypto-random-string');
+import cryptoRandomString from "crypto-random-string";
 
 import {iSubscriptionTracker} from "../../common/models/iSubscriptionTracker";
 import { iView, HtmlString } from "../models/iView";


### PR DESCRIPTION
This changeset switches the `require(...)` statements used to load `crypto-random-string` to `import mod from "...";` statements, so that Rollup properly picks them up and rewrites them.