### PR TITLE
Fix shell command for images on *nix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npx jest",
     "build": "webpack && copy \"index.html\" \"dist/index.html\" && type css\\*.css > dist/bundle.css && xcopy \"img\" \"dist\\img\\\" /E",
-    "build-nix": "webpack && cp \"index.html\" \"dist/index.html\" && cat css/*.css > dist/bundle.css && cp \"img*\" \"dist/img\"",
+    "build-nix": "webpack && cp \"index.html\" \"dist/index.html\" && cat css/*.css > dist/bundle.css && cp -r \"img\" \"dist/img\"",
     "serve": "npm run-script build && webpack-dev-server --open",
     "serve-nix": "npm run-script build-nix && webpack-dev-server --open"
   },


### PR DESCRIPTION
I think a recursive copy works better than an asterisk, especially when the directory hierarchy has multiple levels.