### PR TITLE
Ignore TS error on potentially-`null` object

### DIFF
--- a/src/view/views/menubar/menuBar.view.ts
+++ b/src/view/views/menubar/menuBar.view.ts
@@ -46,6 +46,7 @@ export class MenuBar extends BaseView {
 
     protected onPlacedInDocument(): void {
         let that = this;
+        //@ts-ignore
         const navBar = document.getElementById(this.id).getElementsByTagName("nav")[0]!;
         
         Array.from(document.getElementsByClassName(this.classListenName)).forEach(obj => {


### PR DESCRIPTION
Adds a `@ts-ignore` suppression to a line that was causing an error downstream in the build.